### PR TITLE
Enable rating for weets

### DIFF
--- a/app/controllers/weet/grade-weet.js
+++ b/app/controllers/weet/grade-weet.js
@@ -1,0 +1,15 @@
+const logger = require('../../logger');
+const { scoreWeet } = require('../../services/grades');
+// const { notAcceptableError, LENGTH_WEET } = require('../../errors');
+
+exports.gradeWeet = async (req, res, next) => {
+  try {
+    const { id: weetId } = req.params;
+    const { score } = req.body;
+    const position = await scoreWeet(weetId, score);
+    res.json(`${position.name} position is: ${position.namePosition}`);
+  } catch (error) {
+    logger.error(error);
+    next(error);
+  }
+};

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -17,7 +17,9 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false
       },
       password: { type: DataTypes.STRING, allowNull: false },
-      role: { type: DataTypes.STRING, defaultValue: 'user' }
+      role: { type: DataTypes.STRING, defaultValue: 'user' },
+      points: { type: DataTypes.INTEGER, defaultValue: 0 },
+      position: { type: DataTypes.STRING, defaultValue: 'Developer' }
     },
     {
       timestamps: false,

--- a/app/routes.js
+++ b/app/routes.js
@@ -5,6 +5,7 @@ const { getUsers } = require('./controllers/get-users');
 const { adminUser } = require('./controllers/admin-user');
 const { createWeet } = require('./controllers/weet/create-weet');
 const { getWeets } = require('./controllers/weet/get-weets');
+const { gradeWeet } = require('./controllers/weet/grade-weet');
 const { schemaValidation } = require('./middlewares/schema-validation');
 const emailValidation = require('./middlewares/email-validation');
 const credentialsMatch = require('./middlewares/credentials-match');
@@ -12,6 +13,7 @@ const tokenValidation = require('./middlewares/token-validation');
 const adminTokenValidation = require('./middlewares/admin-token-validation');
 const { signUpSchema, signInSchema, adminSchema } = require('./schemas/user');
 const { paramSchema } = require('./schemas/weet');
+const { scoreSchema } = require('./schemas/grade');
 
 exports.init = app => {
   app.get('/health', healthCheck);
@@ -21,4 +23,5 @@ exports.init = app => {
   app.post('/admin/users', [schemaValidation(adminSchema), adminTokenValidation], adminUser);
   app.post('/weets', [tokenValidation], createWeet);
   app.get('/weets', [tokenValidation, schemaValidation(paramSchema)], getWeets);
+  app.post('/weets/:id/ratings', [tokenValidation, schemaValidation(scoreSchema)], gradeWeet);
 };

--- a/app/schemas/grade.js
+++ b/app/schemas/grade.js
@@ -1,0 +1,10 @@
+const scoreSchema = {
+  score: {
+    matches: {
+      errorMessage: 'The score should be -1 or 1.',
+      options: /(-1|1)$/
+    }
+  }
+};
+
+module.exports = { scoreSchema };

--- a/app/services/grades.js
+++ b/app/services/grades.js
@@ -1,0 +1,51 @@
+const { Weet, Grade, sequelize } = require('../models');
+const { findOne } = require('../services/users');
+const { notFoundError, NOT_WEET } = require('../errors');
+const { positions } = require('../utils/score-position');
+
+const findOneWeet = async condition => {
+  const weet = await Weet.findOne({ where: condition });
+  if (!weet) throw notFoundError('weet schema', NOT_WEET);
+  return weet;
+};
+
+const getPosition = points => positions.find(position => points >= position.min && points < position.max);
+
+const create = async values => {
+  const grade = await Grade.create(values);
+  return grade;
+};
+
+const scoreWeet = async (weetId, score) => {
+  let transaction = {};
+  try {
+    transaction = await sequelize.transaction();
+    const weet = await findOneWeet({ id: weetId });
+    const { id, userId } = weet.dataValues;
+    const user = await findOne({ id: userId });
+    const { points, name } = user.dataValues;
+    let currentPosition = getPosition(points);
+    const newPosition = getPosition(points + score);
+    if (score > 0) {
+      await user.increment('points', { transaction });
+    } else {
+      await user.decrement('points', { transaction });
+    }
+
+    if (currentPosition.namePosition !== newPosition.namePosition) {
+      user.position = newPosition.namePosition;
+      await user.save({ transaction });
+      currentPosition = { ...newPosition };
+    }
+
+    await create({ gradeUserId: userId, weetId: id, score }, transaction);
+
+    await transaction.commit();
+    return { name, namePosition: currentPosition.namePosition };
+  } catch (error) {
+    if (transaction.rollback) await transaction.rollback();
+    throw error;
+  }
+};
+
+module.exports = { scoreWeet };

--- a/app/utils/score-position.js
+++ b/app/utils/score-position.js
@@ -1,8 +1,10 @@
-const developer = { name: 'Developer', min: 0, max: 4 };
-const lead = { name: 'Lead', min: 5, max: 9 };
-const tl = { name: 'TL', min: 10, max: 19 };
-const em = { name: 'EM', min: 20, max: 29 };
-const head = { name: 'HEAD', min: 30, max: 49 };
-const ceo = { name: 'CEO', min: 50 };
+const developer = { namePosition: 'Developer', min: 0, max: 5 };
+const lead = { namePosition: 'Lead', min: 5, max: 10 };
+const tl = { namePosition: 'TL', min: 10, max: 20 };
+const em = { namePosition: 'EM', min: 20, max: 30 };
+const head = { namePosition: 'HEAD', min: 30, max: 50 };
+const ceo = { namePosition: 'CEO', min: 50, max: Infinity };
 
-module.exports = { developer, lead, tl, em, head, ceo };
+const positions = [developer, lead, tl, em, head, ceo];
+
+module.exports = { positions };

--- a/test/grade-weet.test.js
+++ b/test/grade-weet.test.js
@@ -1,0 +1,59 @@
+const request = require('supertest');
+const { factory } = require('factory-girl');
+const app = require('../app');
+const hashString = require('../app/utils/hash-string');
+const { factoryByModel } = require('./factory/factory_by_models');
+
+const mockCredentials = {
+  email: 'r.feynman@wolox.co',
+  password: '12345678#'
+};
+
+factoryByModel('User');
+factoryByModel('Weet');
+
+describe('POST /weets/:id/ratings', () => {
+  let mockToken = null;
+  beforeEach(async () => {
+    await factory.create('User', {
+      email: 'r.feynman@wolox.co',
+      password: hashString('12345678#')
+    });
+    const {
+      body: { token }
+    } = await request(app)
+      .post('/users/sessions')
+      .send(mockCredentials);
+    mockToken = token;
+    await factory.create('Weet', {
+      content: '182,000 Americans die from Chuck Norris-related accidents every year.',
+      userId: 1
+    });
+  });
+  test('Correct parameters', async done => {
+    const response = await request(app)
+      .post(`/weets/${1}/ratings`)
+      .set('Authorization', mockToken)
+      .send({ score: 1 });
+    expect(response.statusCode).toBe(200);
+    done();
+  });
+  test('Incorrect score', async done => {
+    const response = await request(app)
+      .post(`/weets/${1}/ratings`)
+      .set('Authorization', mockToken)
+      .send({ score: 3 });
+    expect(response.statusCode).toBe(422);
+    expect(response.body.errors[0]).toContain('The score should be -1 or 1.');
+    done();
+  });
+  test('Weet does not exist', async done => {
+    const response = await request(app)
+      .post(`/weets/${2}/ratings`)
+      .set('Authorization', mockToken)
+      .send({ score: -1 });
+    expect(response.statusCode).toBe(404);
+    expect(response.body.errors).toContain('It was not possible to get a weet');
+    done();
+  });
+});


### PR DESCRIPTION
## Summary

- Make a request POST to `/weets/:id/ratings`.
- Validate that the score is correct.
- The corresponding modifications in the db were made in the atomic way.

## Trello Card

[Rating](https://trello.com/c/idfypdFO/37-calificar-weet)
